### PR TITLE
fix: maintain search params in navigation links

### DIFF
--- a/app/routes/_authenticated+/tasks+/$task.delete/route.tsx
+++ b/app/routes/_authenticated+/tasks+/$task.delete/route.tsx
@@ -1,6 +1,6 @@
 import { setTimeout as sleep } from 'node:timers/promises'
 import { useState } from 'react'
-import { data, useNavigate } from 'react-router'
+import { data, useNavigate, useSearchParams } from 'react-router'
 import { redirectWithSuccess } from 'remix-toast'
 import { ConfirmDialog } from '~/components/confirm-dialog'
 import { tasks } from '../_shared/data/tasks'
@@ -14,7 +14,8 @@ export const loader = async ({ params }: Route.LoaderArgs) => {
   return { task }
 }
 
-export const action = async ({ params }: Route.ActionArgs) => {
+export const action = async ({ request, params }: Route.ActionArgs) => {
+  const url = new URL(request.url)
   const taskIndex = tasks.findIndex((t) => t.id === params.task)
   if (taskIndex === -1) {
     throw data(null, { status: 404, statusText: 'Task not found' })
@@ -24,7 +25,7 @@ export const action = async ({ params }: Route.ActionArgs) => {
   await sleep(1000)
   tasks.splice(taskIndex, 1)
 
-  return redirectWithSuccess('/tasks', {
+  return redirectWithSuccess(`/tasks?${url.searchParams}`, {
     message: 'Task deleted successfully',
     description: `Task with ID ${params.task} has been deleted.`,
   })
@@ -35,6 +36,7 @@ export default function TaskDelete({
 }: Route.ComponentProps) {
   const [open, setOpen] = useState(true)
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
 
   return (
     <ConfirmDialog
@@ -46,7 +48,7 @@ export default function TaskDelete({
           setOpen(false)
           // wait for the modal to close
           setTimeout(() => {
-            navigate('/tasks', {
+            navigate(`/tasks?${searchParams.toString()}`, {
               viewTransition: true,
             })
           }, 300) // the duration of the modal close animation

--- a/app/routes/_authenticated+/tasks+/$task.update/route.tsx
+++ b/app/routes/_authenticated+/tasks+/$task.update/route.tsx
@@ -1,7 +1,7 @@
 import { parseWithZod } from '@conform-to/zod'
 import { setTimeout as sleep } from 'node:timers/promises'
 import { useState } from 'react'
-import { data, useNavigate } from 'react-router'
+import { data, useNavigate, useSearchParams } from 'react-router'
 import { redirectWithSuccess } from 'remix-toast'
 import {
   TasksMutateDrawer,
@@ -19,6 +19,7 @@ export const loader = async ({ params }: Route.LoaderArgs) => {
 }
 
 export const action = async ({ request }: Route.ActionArgs) => {
+  const url = new URL(request.url)
   const submission = parseWithZod(await request.formData(), {
     schema: updateSchema,
   })
@@ -34,7 +35,7 @@ export const action = async ({ request }: Route.ActionArgs) => {
   }
   tasks.splice(taskIndex, 1, submission.value)
 
-  return redirectWithSuccess('/tasks', {
+  return redirectWithSuccess(`/tasks?${url.searchParams.toString()}`, {
     message: 'Task updated successfully',
     description: `The task ${submission.value.id} has been updated.`,
   })
@@ -45,6 +46,7 @@ export default function TaskUpdate({
 }: Route.ComponentProps) {
   const [open, setOpen] = useState(true)
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
 
   return (
     <TasksMutateDrawer
@@ -56,7 +58,7 @@ export default function TaskUpdate({
           setOpen(false)
           // wait for the drawer to close
           setTimeout(() => {
-            navigate('/tasks', {
+            navigate(`/tasks?${searchParams.toString()}`, {
               viewTransition: true,
             })
           }, 300) // the duration of the drawer close animation

--- a/app/routes/_authenticated+/tasks+/_layout/components/data-table-row-actions.tsx
+++ b/app/routes/_authenticated+/tasks+/_layout/components/data-table-row-actions.tsx
@@ -1,7 +1,7 @@
 import { DotsHorizontalIcon } from '@radix-ui/react-icons'
 import { IconTrash } from '@tabler/icons-react'
 import type { Row } from '@tanstack/react-table'
-import { Link, useFetcher } from 'react-router'
+import { Link, useFetcher, useSearchParams } from 'react-router'
 import { Button } from '~/components/ui/button'
 import {
   DropdownMenu,
@@ -28,6 +28,7 @@ export function DataTableRowActions<TData>({
 }: DataTableRowActionsProps<TData>) {
   const task = taskSchema.parse(row.original)
   const fetcher = useFetcher({ key: `task-label-${task.id}` })
+  const [searchParams] = useSearchParams()
 
   return (
     <DropdownMenu modal={false}>
@@ -42,7 +43,9 @@ export function DataTableRowActions<TData>({
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-[160px]">
         <DropdownMenuItem asChild>
-          <Link to={`/tasks/${task.id}/update`}>Edit</Link>
+          <Link to={`/tasks/${task.id}/update?${searchParams.toString()}`}>
+            Edit
+          </Link>
         </DropdownMenuItem>
         <DropdownMenuItem disabled>Make a copy</DropdownMenuItem>
         <DropdownMenuItem disabled>Favorite</DropdownMenuItem>
@@ -72,7 +75,7 @@ export function DataTableRowActions<TData>({
         </DropdownMenuSub>
         <DropdownMenuSeparator />
         <DropdownMenuItem asChild className="text-red-500">
-          <Link to={`/tasks/${task.id}/delete`}>
+          <Link to={`/tasks/${task.id}/delete?${searchParams.toString()}`}>
             Delete
             <DropdownMenuShortcut>
               <IconTrash size={16} />

--- a/app/routes/_authenticated+/tasks+/_layout/queries.server.ts
+++ b/app/routes/_authenticated+/tasks+/_layout/queries.server.ts
@@ -28,11 +28,15 @@ export const listFilteredTasks = ({
 
   const totalPages = Math.ceil(tasks.length / pageSize)
   const totalItems = tasks.length
+  const newCurrentPage = Math.min(currentPage, totalPages)
 
   return {
-    data: tasks.slice((currentPage - 1) * pageSize, currentPage * pageSize),
+    data: tasks.slice(
+      (newCurrentPage - 1) * pageSize,
+      newCurrentPage * pageSize,
+    ),
     pagination: {
-      currentPage,
+      currentPage: newCurrentPage,
       pageSize,
       totalPages,
       totalItems,
@@ -41,13 +45,13 @@ export const listFilteredTasks = ({
 }
 
 interface GetFacetedCountsArgs {
-  title: string
   facets: string[]
+  title: string
   filters: Record<string, string[]>
 }
 export const getFacetedCounts = ({
-  title,
   facets,
+  title,
   filters,
 }: GetFacetedCountsArgs) => {
   const facetedCounts: Record<string, Record<string, number>> = {}

--- a/app/routes/_authenticated+/tasks+/_layout/route.tsx
+++ b/app/routes/_authenticated+/tasks+/_layout/route.tsx
@@ -1,5 +1,5 @@
 import { IconDownload, IconPlus } from '@tabler/icons-react'
-import { Link, Outlet } from 'react-router'
+import { Link, Outlet, useSearchParams } from 'react-router'
 import { Header } from '~/components/layout/header'
 import { Main } from '~/components/layout/main'
 import { ProfileDropdown } from '~/components/profile-dropdown'
@@ -40,8 +40,8 @@ export const loader = ({ request }: Route.LoaderArgs) => {
 
   // getFacetedCounts is a server-side function that fetches the counts of each filter
   const facetedCounts = getFacetedCounts({
-    title,
     facets: ['status', 'priority'],
+    title,
     filters,
   })
 
@@ -55,6 +55,8 @@ export const loader = ({ request }: Route.LoaderArgs) => {
 export default function Tasks({
   loaderData: { tasks, pagination, facetedCounts },
 }: Route.ComponentProps) {
+  const [searchParams] = useSearchParams()
+
   return (
     <>
       <Header fixed>
@@ -75,12 +77,12 @@ export default function Tasks({
           </div>
           <div className="flex gap-2">
             <Button variant="outline" className="space-x-1" asChild>
-              <Link to="/tasks/import">
+              <Link to={`/tasks/import?${searchParams.toString()}`}>
                 <span>Import</span> <IconDownload size={18} />
               </Link>
             </Button>
             <Button className="space-x-1" asChild>
-              <Link to="/tasks/create">
+              <Link to={`/tasks/create?${searchParams.toString()}`}>
                 <span>Create</span> <IconPlus size={18} />
               </Link>
             </Button>

--- a/app/routes/_authenticated+/tasks+/create/route.tsx
+++ b/app/routes/_authenticated+/tasks+/create/route.tsx
@@ -1,7 +1,7 @@
 import { parseWithZod } from '@conform-to/zod'
 import { setTimeout as sleep } from 'node:timers/promises'
 import { useState } from 'react'
-import { useNavigate } from 'react-router'
+import { useNavigate, useSearchParams } from 'react-router'
 import { redirectWithSuccess } from 'remix-toast'
 import {
   TasksMutateDrawer,
@@ -11,6 +11,7 @@ import { tasks } from '../_shared/data/tasks'
 import type { Route } from './+types/route'
 
 export const action = async ({ request }: Route.ActionArgs) => {
+  const url = new URL(request.url)
   const submission = parseWithZod(await request.formData(), {
     schema: createSchema,
   })
@@ -28,7 +29,7 @@ export const action = async ({ request }: Route.ActionArgs) => {
   const id = `TASK-${String(maxIdNumber + 1).padStart(4, '0')}`
   tasks.unshift({ id, ...task })
 
-  return redirectWithSuccess('/tasks', {
+  return redirectWithSuccess(`/tasks?${url.searchParams.toString()}`, {
     message: 'Task created successfully',
     description: JSON.stringify(submission.value),
   })
@@ -37,6 +38,7 @@ export const action = async ({ request }: Route.ActionArgs) => {
 export default function TaskCreate() {
   const [open, setOpen] = useState(true)
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
 
   return (
     <TasksMutateDrawer
@@ -47,7 +49,7 @@ export default function TaskCreate() {
           setOpen(false)
           // wait for the drawer to close
           setTimeout(() => {
-            navigate('/tasks', {
+            navigate(`/tasks?${searchParams.toString()}`, {
               viewTransition: true,
             })
           }, 300) // the duration of the drawer close animation

--- a/app/routes/_authenticated+/tasks+/import/components/tasks-import-dialog.tsx
+++ b/app/routes/_authenticated+/tasks+/import/components/tasks-import-dialog.tsx
@@ -1,7 +1,6 @@
 import { getFormProps, getInputProps, useForm } from '@conform-to/react'
 import { parseWithZod } from '@conform-to/zod'
 import { Form } from 'react-router'
-import { toast } from 'sonner'
 import type { z } from 'zod'
 import { Button } from '~/components/ui/button'
 import {
@@ -27,26 +26,6 @@ export function TasksImportDialog({ open, onOpenChange }: Props) {
     defaultValue: { file: undefined },
     onValidate: ({ formData }) =>
       parseWithZod(formData, { schema: formSchema }),
-    onSubmit: (event, { submission }) => {
-      event.preventDefault()
-      if (submission?.status !== 'success') return
-      const fileDetails = {
-        name: submission.value.file.name,
-        size: submission.value.file.size,
-        type: submission.value.file.type,
-      }
-
-      toast.success('You have imported the following file:', {
-        description: (
-          <pre className="mt-2 w-[320px] rounded-md bg-slate-950 p-4">
-            <code className="text-white">
-              {JSON.stringify(fileDetails, null, 2)}
-            </code>
-          </pre>
-        ),
-      })
-      onOpenChange(false)
-    },
   })
 
   return (

--- a/app/routes/_authenticated+/tasks+/import/route.tsx
+++ b/app/routes/_authenticated+/tasks+/import/route.tsx
@@ -1,7 +1,7 @@
 import { parseWithZod } from '@conform-to/zod'
 import { setTimeout as sleep } from 'node:timers/promises'
 import { useState } from 'react'
-import { useNavigate } from 'react-router'
+import { useNavigate, useSearchParams } from 'react-router'
 import { redirectWithSuccess } from 'remix-toast'
 import { z } from 'zod'
 import type { Route } from './+types/route'
@@ -17,6 +17,7 @@ export const formSchema = z.object({
 })
 
 export const action = async ({ request }: Route.ActionArgs) => {
+  const url = new URL(request.url)
   const submission = parseWithZod(await request.formData(), {
     schema: formSchema,
   })
@@ -27,7 +28,7 @@ export const action = async ({ request }: Route.ActionArgs) => {
   await sleep(1000)
 
   // Create a new task
-  return redirectWithSuccess('/tasks', {
+  return redirectWithSuccess(`/tasks?${url.search.toString()}`, {
     message: 'Tasks imported successfully.',
     description: JSON.stringify(submission.value),
   })
@@ -36,6 +37,7 @@ export const action = async ({ request }: Route.ActionArgs) => {
 export default function TaskImport() {
   const [open, setOpen] = useState(true)
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
 
   return (
     <TasksImportDialog
@@ -46,7 +48,7 @@ export default function TaskImport() {
           setOpen(false)
           // wait for the modal to close
           setTimeout(() => {
-            navigate('/tasks', {
+            navigate(`/tasks?${searchParams.toString()}`, {
               viewTransition: true,
             })
           }, 300) // the duration of the modal close animation


### PR DESCRIPTION
This pull request introduces several changes to improve the handling of search parameters in task-related routes. The modifications ensure that search parameters are preserved across various task actions such as delete, update, create, and import. Additionally, there are some minor improvements and refactoring to enhance the codebase.

Improvements to task routes:

* [`app/routes/_authenticated+/tasks+/$task.delete/route.tsx`](diffhunk://#diff-71f5b62db92e3df2dbe0638a20d073f08511ccf30f7c22f1d394ebd95997278bL3-R3): Added `useSearchParams` to preserve search parameters when deleting a task. [[1]](diffhunk://#diff-71f5b62db92e3df2dbe0638a20d073f08511ccf30f7c22f1d394ebd95997278bL3-R3) [[2]](diffhunk://#diff-71f5b62db92e3df2dbe0638a20d073f08511ccf30f7c22f1d394ebd95997278bL17-R18) [[3]](diffhunk://#diff-71f5b62db92e3df2dbe0638a20d073f08511ccf30f7c22f1d394ebd95997278bL27-R28) [[4]](diffhunk://#diff-71f5b62db92e3df2dbe0638a20d073f08511ccf30f7c22f1d394ebd95997278bR39) [[5]](diffhunk://#diff-71f5b62db92e3df2dbe0638a20d073f08511ccf30f7c22f1d394ebd95997278bL49-R51)
* [`app/routes/_authenticated+/tasks+/$task.update/route.tsx`](diffhunk://#diff-b00dde3b4f16ec82be9e56a2b07dfae73ae33f2f7edf64dd11f1f8afd001ba01L4-R4): Added `useSearchParams` to preserve search parameters when updating a task. [[1]](diffhunk://#diff-b00dde3b4f16ec82be9e56a2b07dfae73ae33f2f7edf64dd11f1f8afd001ba01L4-R4) [[2]](diffhunk://#diff-b00dde3b4f16ec82be9e56a2b07dfae73ae33f2f7edf64dd11f1f8afd001ba01R22) [[3]](diffhunk://#diff-b00dde3b4f16ec82be9e56a2b07dfae73ae33f2f7edf64dd11f1f8afd001ba01L37-R38) [[4]](diffhunk://#diff-b00dde3b4f16ec82be9e56a2b07dfae73ae33f2f7edf64dd11f1f8afd001ba01R49) [[5]](diffhunk://#diff-b00dde3b4f16ec82be9e56a2b07dfae73ae33f2f7edf64dd11f1f8afd001ba01L59-R61)
* [`app/routes/_authenticated+/tasks+/create/route.tsx`](diffhunk://#diff-8f2e82d09138d8b58246c43d6ef73c267b1609b090e512a1c3ba26093d673509L4-R4): Added `useSearchParams` to preserve search parameters when creating a task. [[1]](diffhunk://#diff-8f2e82d09138d8b58246c43d6ef73c267b1609b090e512a1c3ba26093d673509L4-R4) [[2]](diffhunk://#diff-8f2e82d09138d8b58246c43d6ef73c267b1609b090e512a1c3ba26093d673509R14) [[3]](diffhunk://#diff-8f2e82d09138d8b58246c43d6ef73c267b1609b090e512a1c3ba26093d673509L31-R32) [[4]](diffhunk://#diff-8f2e82d09138d8b58246c43d6ef73c267b1609b090e512a1c3ba26093d673509R41) [[5]](diffhunk://#diff-8f2e82d09138d8b58246c43d6ef73c267b1609b090e512a1c3ba26093d673509L50-R52)
* [`app/routes/_authenticated+/tasks+/import/route.tsx`](diffhunk://#diff-bcc2145237cc041085c8ecf082a3e089de05e374775bc20b548126a9be1f8528L4-R4): Added `useSearchParams` to preserve search parameters when importing tasks. [[1]](diffhunk://#diff-bcc2145237cc041085c8ecf082a3e089de05e374775bc20b548126a9be1f8528L4-R4) [[2]](diffhunk://#diff-bcc2145237cc041085c8ecf082a3e089de05e374775bc20b548126a9be1f8528R20) [[3]](diffhunk://#diff-bcc2145237cc041085c8ecf082a3e089de05e374775bc20b548126a9be1f8528L30-R31) [[4]](diffhunk://#diff-bcc2145237cc041085c8ecf082a3e089de05e374775bc20b548126a9be1f8528R40) [[5]](diffhunk://#diff-bcc2145237cc041085c8ecf082a3e089de05e374775bc20b548126a9be1f8528L49-R51)

Refactoring and minor improvements:

* [`app/routes/_authenticated+/tasks+/_layout/components/data-table-row-actions.tsx`](diffhunk://#diff-bebe455ad22e918944f1de00f88a1485bb04c01d3c9a5defae07b7b743331d63L4-R4): Added `useSearchParams` to preserve search parameters in data table row actions. [[1]](diffhunk://#diff-bebe455ad22e918944f1de00f88a1485bb04c01d3c9a5defae07b7b743331d63L4-R4) [[2]](diffhunk://#diff-bebe455ad22e918944f1de00f88a1485bb04c01d3c9a5defae07b7b743331d63R31) [[3]](diffhunk://#diff-bebe455ad22e918944f1de00f88a1485bb04c01d3c9a5defae07b7b743331d63L45-R48) [[4]](diffhunk://#diff-bebe455ad22e918944f1de00f88a1485bb04c01d3c9a5defae07b7b743331d63L75-R78)
* [`app/routes/_authenticated+/tasks+/_layout/queries.server.ts`](diffhunk://#diff-49656a184f51d40388dbc2581a57bac6fefdec5580722a33caf8f0b7df3f6fd1R31-R39): Adjusted pagination logic to handle cases where the current page exceeds the total number of pages. [[1]](diffhunk://#diff-49656a184f51d40388dbc2581a57bac6fefdec5580722a33caf8f0b7df3f6fd1R31-R39) [[2]](diffhunk://#diff-49656a184f51d40388dbc2581a57bac6fefdec5580722a33caf8f0b7df3f6fd1L44-R54)
* [`app/routes/_authenticated+/tasks+/_layout/route.tsx`](diffhunk://#diff-e73681afc2514815299a04f3a4b81a70fc22c34a495a31deba6719582fee2d22L2-R2): Added `useSearchParams` to preserve search parameters in the main tasks layout. [[1]](diffhunk://#diff-e73681afc2514815299a04f3a4b81a70fc22c34a495a31deba6719582fee2d22L2-R2) [[2]](diffhunk://#diff-e73681afc2514815299a04f3a4b81a70fc22c34a495a31deba6719582fee2d22L43-R44) [[3]](diffhunk://#diff-e73681afc2514815299a04f3a4b81a70fc22c34a495a31deba6719582fee2d22R58-R59) [[4]](diffhunk://#diff-e73681afc2514815299a04f3a4b81a70fc22c34a495a31deba6719582fee2d22L78-R85)
* [`app/routes/_authenticated+/tasks+/import/components/tasks-import-dialog.tsx`](diffhunk://#diff-e3ff5704a99354fd383d2a989c86ea5e4381894002d921ea9f9ff31162d31985L4): Removed unused `sonner` import and related code. [[1]](diffhunk://#diff-e3ff5704a99354fd383d2a989c86ea5e4381894002d921ea9f9ff31162d31985L4) [[2]](diffhunk://#diff-e3ff5704a99354fd383d2a989c86ea5e4381894002d921ea9f9ff31162d31985L30-L49)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes: Tasks Navigation and Search Parameter Preservation

- **New Features**
  - Enhanced task management navigation to preserve search parameters across different routes
  - Improved URL handling when editing, deleting, creating, and importing tasks

- **Improvements**
  - Search parameters are now consistently maintained during task-related actions
  - Pagination logic updated to prevent out-of-bounds page navigation
  - More robust handling of URL parameters across task management workflows

- **Technical Enhancements**
  - Added `useSearchParams` hook to multiple task-related components
  - Refined redirection mechanisms to include existing search parameters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->