### PR TITLE
feat: implement optimistic updates for task labels with new route handling

### DIFF
--- a/app/routes/_authenticated+/tasks+/$task.label/route.ts
+++ b/app/routes/_authenticated+/tasks+/$task.label/route.ts
@@ -1,0 +1,29 @@
+import { parseWithZod } from '@conform-to/zod'
+import { setTimeout } from 'node:timers/promises'
+import { dataWithError, dataWithSuccess } from 'remix-toast'
+import { z } from 'zod'
+import { tasks } from '../_shared/data/tasks'
+import type { Route } from './+types/route'
+
+export const action = async ({ request, params }: Route.ActionArgs) => {
+  const taskIndex = tasks.findIndex((t) => t.id === params.task)
+  if (taskIndex === -1) {
+    throw dataWithError(null, { message: 'Task not found' })
+  }
+
+  const submission = parseWithZod(await request.formData(), {
+    schema: z.object({ label: z.string() }),
+  })
+  if (submission.status !== 'success') {
+    throw dataWithError(submission.error, { message: 'Invalid submission' })
+  }
+
+  // update task label
+  await setTimeout(1000)
+  tasks[taskIndex].label = submission.value.label
+
+  return dataWithSuccess(null, {
+    message: 'Task label updated successfully',
+    description: `Task ${params.task} label has been updated to ${submission.value.label}`,
+  })
+}

--- a/app/routes/_authenticated+/tasks+/_layout/components/columns.tsx
+++ b/app/routes/_authenticated+/tasks+/_layout/components/columns.tsx
@@ -1,4 +1,5 @@
 import type { ColumnDef } from '@tanstack/react-table'
+import { useFetcher } from 'react-router'
 import { Badge } from '~/components/ui/badge'
 import { Checkbox } from '~/components/ui/checkbox'
 import { labels, priorities, statuses } from '../../_shared/data/data'
@@ -47,10 +48,16 @@ export const columns: ColumnDef<Task>[] = [
     ),
     cell: ({ row }) => {
       const label = labels.find((label) => label.value === row.original.label)
+      const fetcher = useFetcher({ key: `task-label-${row.original.id}` }) // for optimistic update
 
       return (
         <div className="flex space-x-2">
-          {label && <Badge variant="outline">{label.label}</Badge>}
+          {label && (
+            <Badge variant="outline" className="capitalize">
+              {fetcher.formData?.get('label')?.toString() ?? label.label}
+            </Badge>
+          )}
+
           <span className="max-w-32 truncate font-medium sm:max-w-72 md:max-w-[31rem]">
             {row.getValue('title')}
           </span>

--- a/app/routes/_authenticated+/tasks+/_layout/components/data-table-row-actions.tsx
+++ b/app/routes/_authenticated+/tasks+/_layout/components/data-table-row-actions.tsx
@@ -59,7 +59,7 @@ export function DataTableRowActions<TData>({
                 fetcher.submit(
                   { id: task.id, label: value },
                   {
-                    action: '/tasks',
+                    action: `/tasks/${task.id}/label`,
                     method: 'POST',
                   },
                 )


### PR DESCRIPTION
This pull request includes changes to the task management feature, specifically focusing on updating task labels. The most important changes involve adding a new route for updating task labels, integrating optimistic updates in the task table, and modifying the form submission path for task label updates.

### Task Label Update Feature:

* [`app/routes/_authenticated+/tasks+/$task.label/route.ts`](diffhunk://#diff-7ee7fdec0653d998bd6741e46a7366950a1a00920864a8544eb9925246ed0594R1-R29): Added a new route to handle task label updates using `parseWithZod` for validation and `remix-toast` for success/error handling.

### Optimistic Updates:

* [`app/routes/_authenticated+/tasks+/_layout/components/columns.tsx`](diffhunk://#diff-758346ae740ba4b9aafdeca9dfe91cbea248c17569957548a7d66d55a233676bR2): Integrated `useFetcher` to enable optimistic updates for task labels in the task table. [[1]](diffhunk://#diff-758346ae740ba4b9aafdeca9dfe91cbea248c17569957548a7d66d55a233676bR2) [[2]](diffhunk://#diff-758346ae740ba4b9aafdeca9dfe91cbea248c17569957548a7d66d55a233676bR51-R60)

### Form Submission Path:

* [`app/routes/_authenticated+/tasks+/_layout/components/data-table-row-actions.tsx`](diffhunk://#diff-bebe455ad22e918944f1de00f88a1485bb04c01d3c9a5defae07b7b743331d63L62-R62): Updated the form submission path to use the new task label update route

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added ability to update task labels with optimistic UI updates
	- Implemented label update validation and error handling

- **Bug Fixes**
	- Improved task label update routing to be task-specific

- **Refactor**
	- Enhanced task label management with more precise routing and validation mechanisms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->