### PR TITLE
feat: implement useSmartNavigation hook for improved navigation handl…

### DIFF
--- a/app/hooks/use-smart-navigation.ts
+++ b/app/hooks/use-smart-navigation.ts
@@ -1,0 +1,70 @@
+import { useEffect } from 'react'
+import { useLocation, useNavigate } from 'react-router'
+
+/**
+ * A smart navigation hook that can automatically save the current location and provide a goBack function.
+ *
+ * @param options - Configuration options for the smart navigation
+ * @param options.autoSave - Whether to automatically save the current location to sessionStorage. Defaults to false.
+ * @param options.baseUrl - The base URL of the nested route. Used as the storage key and fallback URL. Defaults to '/'.
+ *
+ * @returns An object containing the goBack function and backUrl
+ * @returns goBack - A function that navigates back to the saved location or fallback URL
+ * @returns backUrl - The saved URL or base URL that goBack will navigate to
+ *
+ * @example
+ * ```typescript
+ * // Usage on a list page - automatically save current location with filters/pagination
+ * const { goBack } = useSmartNavigation({
+ *   autoSave: true,
+ *   baseUrl: '/tasks'
+ * })
+ *
+ * // Usage on a detail page - provide goBack function to return to saved list location
+ * const { goBack, backUrl } = useSmartNavigation({
+ *   autoSave: false,
+ *   baseUrl: '/tasks'
+ * })
+ *
+ * // Navigate back to saved list location (e.g., on save/cancel button)
+ * goBack()
+ *
+ * // Or use backUrl for Link component
+ * <Link to={backUrl}>Back to List</Link>
+ * ```
+ */
+export function useSmartNavigation(options?: {
+  autoSave?: boolean
+  baseUrl?: string
+}) {
+  const location = useLocation()
+  const navigate = useNavigate()
+
+  const { autoSave = false, baseUrl = '/' } = options || {}
+
+  // 自動保存
+  useEffect(() => {
+    if (autoSave && baseUrl === location.pathname) {
+      sessionStorage.setItem(
+        `nav_${baseUrl}`,
+        location.pathname + location.search,
+      )
+    }
+  }, [location, baseUrl, autoSave])
+
+  // SSR-safe fallback
+  const getBackUrl = () => {
+    if (typeof window === 'undefined') return baseUrl // SSR
+    const savedUrl = sessionStorage.getItem(`nav_${baseUrl}`)
+    return savedUrl || baseUrl
+  }
+
+  const goBack = () => {
+    navigate(getBackUrl())
+  }
+
+  return {
+    goBack,
+    backUrl: getBackUrl(),
+  }
+}

--- a/app/routes/_authenticated+/tasks+/$task.delete/route.tsx
+++ b/app/routes/_authenticated+/tasks+/$task.delete/route.tsx
@@ -1,6 +1,6 @@
 import { setTimeout as sleep } from 'node:timers/promises'
 import { useEffect } from 'react'
-import { data, useFetcher } from 'react-router'
+import { data, href, useFetcher } from 'react-router'
 import { dataWithSuccess } from 'remix-toast'
 import { ConfirmDialog } from '~/components/confirm-dialog'
 import type { Task } from '../_shared/data/schema'
@@ -52,7 +52,7 @@ export function TaskDeleteConfirmDialog({
       className="max-w-md"
       title={`Delete this task: ${task.id} ?`}
       fetcher={fetcher}
-      action={`/tasks/${task.id}/delete`}
+      action={href('/tasks/:task/delete', { task: task.id })}
       desc={
         <>
           You are about to delete a task with the ID <strong>{task.id}</strong>.{' '}

--- a/app/routes/_authenticated+/tasks+/_index/components/data-table-pagination.tsx
+++ b/app/routes/_authenticated+/tasks+/_index/components/data-table-pagination.tsx
@@ -73,9 +73,7 @@ export function DataTablePagination<TData>({
             variant="outline"
             className="hidden h-8 w-8 p-0 lg:flex"
             onClick={() => {
-              updatePagination({
-                page: undefined, // delete page param
-              })
+              updatePagination({ page: undefined })
             }}
             disabled={page === 1}
           >
@@ -87,9 +85,7 @@ export function DataTablePagination<TData>({
             variant="outline"
             className="h-8 w-8 p-0"
             onClick={() => {
-              updatePagination({
-                page: page === 2 ? undefined : page - 1,
-              })
+              updatePagination({ page: page === 2 ? undefined : page - 1 })
             }}
             disabled={page === 1}
           >
@@ -101,9 +97,7 @@ export function DataTablePagination<TData>({
             variant="outline"
             className="h-8 w-8 p-0"
             onClick={() => {
-              updatePagination({
-                page: page + 1,
-              })
+              updatePagination({ page: page + 1 })
             }}
             disabled={page === totalPages || totalPages === 1}
           >
@@ -115,9 +109,7 @@ export function DataTablePagination<TData>({
             variant="outline"
             className="hidden h-8 w-8 p-0 lg:flex"
             onClick={() => {
-              updatePagination({
-                page: totalPages,
-              })
+              updatePagination({ page: totalPages })
             }}
             disabled={page === totalPages || totalPages === 1}
           >

--- a/app/routes/_authenticated+/tasks+/_index/components/data-table-row-actions.tsx
+++ b/app/routes/_authenticated+/tasks+/_index/components/data-table-row-actions.tsx
@@ -2,7 +2,7 @@ import { DotsHorizontalIcon } from '@radix-ui/react-icons'
 import { IconTrash } from '@tabler/icons-react'
 import type { Row } from '@tanstack/react-table'
 import { useState } from 'react'
-import { Link, useFetcher, useSearchParams } from 'react-router'
+import { href, Link, useFetcher } from 'react-router'
 import { Button } from '~/components/ui/button'
 import {
   DropdownMenu,
@@ -30,7 +30,6 @@ export function DataTableRowActions<TData>({
 }: DataTableRowActionsProps<TData>) {
   const task = taskSchema.parse(row.original)
   const fetcher = useFetcher({ key: `task-label-${task.id}` })
-  const [searchParams] = useSearchParams()
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
 
   return (
@@ -47,9 +46,7 @@ export function DataTableRowActions<TData>({
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-[160px]">
           <DropdownMenuItem asChild>
-            <Link to={`/tasks/${task.id}?${searchParams.toString()}`}>
-              Edit
-            </Link>
+            <Link to={href('/tasks/:task', { task: task.id })}>Edit</Link>
           </DropdownMenuItem>
           <DropdownMenuItem disabled>Make a copy</DropdownMenuItem>
           <DropdownMenuItem disabled>Favorite</DropdownMenuItem>
@@ -63,7 +60,7 @@ export function DataTableRowActions<TData>({
                   fetcher.submit(
                     { id: task.id, label: value },
                     {
-                      action: `/tasks/${task.id}/label`,
+                      action: href('/tasks/:task/label', { task: task.id }),
                       method: 'POST',
                     },
                   )

--- a/app/routes/_authenticated+/tasks+/_index/route.tsx
+++ b/app/routes/_authenticated+/tasks+/_index/route.tsx
@@ -1,6 +1,7 @@
 import { IconDownload, IconPlus } from '@tabler/icons-react'
-import { Link } from 'react-router'
+import { href, Link } from 'react-router'
 import { Button } from '~/components/ui/button'
+import { useSmartNavigation } from '~/hooks/use-smart-navigation'
 import type { Route } from './+types/route'
 import { DataTable } from './components/data-table'
 import { columns, parseQueryParams } from './config'
@@ -37,6 +38,8 @@ export const loader = ({ request }: Route.LoaderArgs) => {
 export default function Tasks({
   loaderData: { tasks, pagination, facetedCounts },
 }: Route.ComponentProps) {
+  useSmartNavigation({ autoSave: true, baseUrl: href('/tasks') })
+
   return (
     <div>
       <div className="mb-2 flex flex-wrap items-center justify-between space-y-2 gap-x-4">
@@ -48,12 +51,12 @@ export default function Tasks({
         </div>
         <div className="flex gap-2">
           <Button variant="outline" className="space-x-1" asChild>
-            <Link to="/tasks/import">
+            <Link to={href('/tasks/import')}>
               <span>Import</span> <IconDownload size={18} />
             </Link>
           </Button>
           <Button className="space-x-1" asChild>
-            <Link to="/tasks/create">
+            <Link to={href('/tasks/create')}>
               <span>Create</span> <IconPlus size={18} />
             </Link>
           </Button>

--- a/app/routes/_authenticated+/tasks+/_layout/hooks/use-breadcrumbs.tsx
+++ b/app/routes/_authenticated+/tasks+/_layout/hooks/use-breadcrumbs.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Link, useMatches } from 'react-router'
+import { href, Link, useMatches } from 'react-router'
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -49,7 +49,7 @@ export const useBreadcrumbs = () => {
           <BreadcrumbList className="px-4">
             <BreadcrumbItem>
               <BreadcrumbLink asChild>
-                <Link to="/">Home</Link>
+                <Link to={href('/')}>Home</Link>
               </BreadcrumbLink>
             </BreadcrumbItem>
 

--- a/app/routes/_authenticated+/tasks+/_shared/components/tasks-mutate-form.tsx
+++ b/app/routes/_authenticated+/tasks+/_shared/components/tasks-mutate-form.tsx
@@ -1,6 +1,6 @@
 import { getFormProps, getInputProps, useForm } from '@conform-to/react'
 import { parseWithZod } from '@conform-to/zod'
-import { Form, Link, useNavigation } from 'react-router'
+import { Form, href, Link, useNavigation } from 'react-router'
 import { z } from 'zod'
 import { Button } from '~/components/ui/button'
 import { Input } from '~/components/ui/input'
@@ -14,6 +14,7 @@ import {
   SelectValue,
 } from '~/components/ui/select'
 import { HStack } from '~/components/ui/stack'
+import { useSmartNavigation } from '~/hooks/use-smart-navigation'
 import type { Task } from '../data/schema'
 
 export const createSchema = z.object({
@@ -48,6 +49,7 @@ export function TasksMutateForm({ task }: { task?: Task }) {
       parseWithZod(formData, { schema: formSchema }),
   })
   const navigation = useNavigation()
+  const { backUrl } = useSmartNavigation({ baseUrl: href('/tasks') })
 
   return (
     <Form method="POST" {...getFormProps(form)} className="space-y-5">
@@ -186,7 +188,7 @@ export function TasksMutateForm({ task }: { task?: Task }) {
 
       <HStack className="gap-2">
         <Button variant="link" asChild>
-          <Link to="/tasks">Cancel</Link>
+          <Link to={backUrl}>Cancel</Link>
         </Button>
         <Button
           form={form.id}

--- a/app/routes/_authenticated+/tasks+/create/route.tsx
+++ b/app/routes/_authenticated+/tasks+/create/route.tsx
@@ -1,5 +1,6 @@
 import { parseWithZod } from '@conform-to/zod'
 import { setTimeout as sleep } from 'node:timers/promises'
+import { href } from 'react-router'
 import { redirectWithSuccess } from 'remix-toast'
 import { Separator } from '~/components/ui/separator'
 import {
@@ -31,7 +32,7 @@ export const action = async ({ request }: Route.ActionArgs) => {
   const id = `TASK-${String(maxIdNumber + 1).padStart(4, '0')}`
   tasks.unshift({ id, ...task })
 
-  return redirectWithSuccess('/tasks', {
+  return redirectWithSuccess(href('/tasks'), {
     message: 'Task created successfully',
     description: JSON.stringify(submission.value),
   })

--- a/app/routes/_authenticated+/tasks+/import/route.tsx
+++ b/app/routes/_authenticated+/tasks+/import/route.tsx
@@ -1,7 +1,7 @@
 import { getFormProps, getInputProps, useForm } from '@conform-to/react'
 import { parseWithZod } from '@conform-to/zod'
 import { setTimeout as sleep } from 'node:timers/promises'
-import { Form, Link } from 'react-router'
+import { Form, href, Link } from 'react-router'
 import { redirectWithSuccess } from 'remix-toast'
 import { z } from 'zod'
 import { Button } from '~/components/ui/button'
@@ -9,6 +9,7 @@ import { Input } from '~/components/ui/input'
 import { Label } from '~/components/ui/label'
 import { Separator } from '~/components/ui/separator'
 import { HStack } from '~/components/ui/stack'
+import { useSmartNavigation } from '~/hooks/use-smart-navigation'
 import type { Route } from './+types/route'
 
 export const formSchema = z.object({
@@ -47,6 +48,7 @@ export default function TaskImport() {
     onValidate: ({ formData }) =>
       parseWithZod(formData, { schema: formSchema }),
   })
+  const { backUrl } = useSmartNavigation({ baseUrl: href('/tasks') })
 
   return (
     <div>
@@ -73,7 +75,7 @@ export default function TaskImport() {
 
         <HStack>
           <Button variant="link" asChild>
-            <Link to="/tasks">Cancel</Link>
+            <Link to={backUrl}>Cancel</Link>
           </Button>
           <Button type="submit">Import</Button>
         </HStack>

--- a/app/routes/_authenticated+/users+/$user.delete/route.tsx
+++ b/app/routes/_authenticated+/users+/$user.delete/route.tsx
@@ -1,7 +1,8 @@
 import { setTimeout as sleep } from 'node:timers/promises'
 import { useState } from 'react'
-import { data, useNavigate, useSearchParams } from 'react-router'
+import { data, href } from 'react-router'
 import { redirectWithSuccess } from 'remix-toast'
+import { useSmartNavigation } from '~/hooks/use-smart-navigation'
 import { users } from '../_shared/data/users'
 import type { Route } from './+types/route'
 import { UsersDeleteDialog } from './components/users-delete-dialog'
@@ -37,8 +38,7 @@ export default function UserDelete({
   loaderData: { user },
 }: Route.ComponentProps) {
   const [open, setOpen] = useState(true)
-  const navigate = useNavigate()
-  const [searchParams] = useSearchParams()
+  const { goBack } = useSmartNavigation({ baseUrl: href('/users') })
 
   return (
     <UsersDeleteDialog
@@ -50,7 +50,7 @@ export default function UserDelete({
           setOpen(false)
           // wait for the drawer to close
           setTimeout(() => {
-            navigate(`/users?${searchParams.toString()}`)
+            goBack()
           }, 300) // the duration of the modal close animation
         }
       }}

--- a/app/routes/_authenticated+/users+/$user.update/route.tsx
+++ b/app/routes/_authenticated+/users+/$user.update/route.tsx
@@ -1,8 +1,9 @@
 import { parseWithZod } from '@conform-to/zod'
 import { setTimeout as sleep } from 'node:timers/promises'
 import { useState } from 'react'
-import { data, useNavigate, useSearchParams } from 'react-router'
+import { data, href } from 'react-router'
 import { redirectWithSuccess } from 'remix-toast'
+import { useSmartNavigation } from '~/hooks/use-smart-navigation'
 import {
   UsersActionDialog,
   editSchema as formSchema,
@@ -55,9 +56,7 @@ export default function UserUpdate({
   loaderData: { user },
 }: Route.ComponentProps) {
   const [open, setOpen] = useState(true)
-  const navigate = useNavigate()
-  const [searchParams] = useSearchParams()
-
+  const { goBack } = useSmartNavigation({ baseUrl: href('/users') })
   return (
     <UsersActionDialog
       key={`user-edit-${user.id}`}
@@ -68,7 +67,7 @@ export default function UserUpdate({
           setOpen(false)
           // wait for the modal to close
           setTimeout(() => {
-            navigate(`/users?${searchParams.toString()}`)
+            goBack()
           }, 300) // the duration of the modal close animation
         }
       }}

--- a/app/routes/_authenticated+/users+/_layout/components/data-table-row-actions.tsx
+++ b/app/routes/_authenticated+/users+/_layout/components/data-table-row-actions.tsx
@@ -1,7 +1,7 @@
 import { DotsHorizontalIcon } from '@radix-ui/react-icons'
 import { IconEdit, IconTrash } from '@tabler/icons-react'
 import type { Row } from '@tanstack/react-table'
-import { Link, useSearchParams } from 'react-router'
+import { href, Link } from 'react-router'
 import { Button } from '~/components/ui/button'
 import {
   DropdownMenu,
@@ -18,7 +18,6 @@ interface DataTableRowActionsProps {
 }
 
 export function DataTableRowActions({ row }: DataTableRowActionsProps) {
-  const [searchParams] = useSearchParams()
   return (
     <>
       <DropdownMenu modal={false}>
@@ -33,9 +32,7 @@ export function DataTableRowActions({ row }: DataTableRowActionsProps) {
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-[160px]">
           <DropdownMenuItem asChild>
-            <Link
-              to={`/users/${row.original.id}/update?${searchParams.toString()}`}
-            >
+            <Link to={href('/users/:user/update', { user: row.original.id })}>
               Edit
               <DropdownMenuShortcut>
                 <IconEdit size={16} />
@@ -44,9 +41,7 @@ export function DataTableRowActions({ row }: DataTableRowActionsProps) {
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem asChild className="text-red-500">
-            <Link
-              to={`/users/${row.original.id}/delete?${searchParams.toString()}`}
-            >
+            <Link to={href('/users/:user/delete', { user: row.original.id })}>
               Delete
               <DropdownMenuShortcut>
                 <IconTrash size={16} />

--- a/app/routes/_authenticated+/users+/_layout/route.tsx
+++ b/app/routes/_authenticated+/users+/_layout/route.tsx
@@ -1,11 +1,12 @@
 import { IconMailPlus, IconUserPlus } from '@tabler/icons-react'
-import { Link, Outlet, useSearchParams } from 'react-router'
+import { href, Link, Outlet } from 'react-router'
 import { Header } from '~/components/layout/header'
 import { Main } from '~/components/layout/main'
 import { ProfileDropdown } from '~/components/profile-dropdown'
 import { Search } from '~/components/search'
 import { ThemeSwitch } from '~/components/theme-switch'
 import { Button } from '~/components/ui/button'
+import { useSmartNavigation } from '~/hooks/use-smart-navigation'
 import type { Route } from './+types/route'
 import { columns } from './components/users-columns'
 import { UsersTable } from './components/users-table'
@@ -60,7 +61,8 @@ export const loader = ({ request }: Route.LoaderArgs) => {
 export default function Users({
   loaderData: { users, pagination, facetedCounts },
 }: Route.ComponentProps) {
-  const [searchParams] = useSearchParams()
+  useSmartNavigation({ autoSave: true, baseUrl: href('/users') })
+
   return (
     <>
       <Header fixed>
@@ -81,12 +83,12 @@ export default function Users({
           </div>
           <div className="flex gap-2">
             <Button variant="outline" className="space-x-1" asChild>
-              <Link to={`/users/invite?${searchParams.toString()}`}>
+              <Link to={href('/users/invite')}>
                 <span>Invite User</span> <IconMailPlus size={18} />
               </Link>
             </Button>
             <Button className="space-x-1" asChild>
-              <Link to={`/users/add?${searchParams.toString()}`}>
+              <Link to={href('/users/add')}>
                 <span>Add User</span> <IconUserPlus size={18} />
               </Link>
             </Button>

--- a/app/routes/_authenticated+/users+/add/route.tsx
+++ b/app/routes/_authenticated+/users+/add/route.tsx
@@ -1,8 +1,9 @@
 import { parseWithZod } from '@conform-to/zod'
 import { setTimeout as sleep } from 'node:timers/promises'
 import { useState } from 'react'
-import { useNavigate, useSearchParams } from 'react-router'
+import { href } from 'react-router'
 import { redirectWithSuccess } from 'remix-toast'
+import { useSmartNavigation } from '~/hooks/use-smart-navigation'
 import {
   UsersActionDialog,
   createSchema as formSchema,
@@ -38,8 +39,9 @@ export const action = async ({ request }: Route.ActionArgs) => {
 
 export default function UserAdd() {
   const [open, setOpen] = useState(true)
-  const navigate = useNavigate()
-  const [searchParams] = useSearchParams()
+  const { goBack } = useSmartNavigation({
+    baseUrl: href('/users'),
+  })
 
   return (
     <UsersActionDialog
@@ -48,9 +50,11 @@ export default function UserAdd() {
       onOpenChange={(v) => {
         if (!v) {
           setOpen(false)
+          console.log('UserAdd dialog closed')
           // wait for the modal to close
           setTimeout(() => {
-            navigate(`/users?${searchParams.toString()}`)
+            console.log('Navigating back to users list')
+            goBack()
           }, 300) // the duration of the modal close animation
         }
       }}

--- a/app/routes/_authenticated+/users+/invite/route.tsx
+++ b/app/routes/_authenticated+/users+/invite/route.tsx
@@ -1,9 +1,10 @@
 import { parseWithZod } from '@conform-to/zod'
 import { setTimeout as sleep } from 'node:timers/promises'
 import { useState } from 'react'
-import { useNavigate, useSearchParams } from 'react-router'
+import { href } from 'react-router'
 import { redirectWithSuccess } from 'remix-toast'
 import { z } from 'zod'
+import { useSmartNavigation } from '~/hooks/use-smart-navigation'
 import type { Route } from './+types/route'
 import { UsersInviteDialog } from './components/users-invite-dialog'
 
@@ -34,8 +35,7 @@ export const action = async ({ request }: Route.ActionArgs) => {
 
 export default function UserInvite() {
   const [open, setOpen] = useState(true)
-  const navigate = useNavigate()
-  const [searchParams] = useSearchParams()
+  const { goBack } = useSmartNavigation({ baseUrl: href('/users') })
 
   return (
     <UsersInviteDialog
@@ -46,7 +46,7 @@ export default function UserInvite() {
           setOpen(false)
           // wait for the drawer to close
           setTimeout(() => {
-            navigate(`/users?${searchParams.toString()}`)
+            goBack()
           }, 300) // the duration of the modal close animation
         }
       }}


### PR DESCRIPTION

このプルリクエストでは、アプリケーション全体のナビゲーション体験と開発効率を向上させるため、新しいカスタムフック `useSmartNavigation` の導入と、`react-router` の `href` ユーティリティ関数への移行を行いました。

**主な変更点:**

1.  **`useSmartNavigation` フックの新規作成 (`app/hooks/use-smart-navigation.ts`)**
    *   一覧ページなどで適用されたフィルタやページネーションの状態を含むURLを `sessionStorage` に自動的に保存する機能を提供します (`autoSave: true` の場合)。
    *   `goBack` 関数と `backUrl` を提供し、保存されたURLまたは指定されたベースURLへ簡単に戻れるようにします。
    *   これにより、ユーザーが詳細ページから一覧に戻った際に、以前の表示状態（フィルタ、ページネーションなど）が保持されるようになります。
    *   SSR環境でも安全に動作するようにフォールバック処理を含んでいます。

2.  **`react-router` の `href` ユーティリティの活用**
    *   アプリケーション内の `Link` コンポーネントの `to` 属性や、`fetcher` の `action` 属性などで使用するURLパスを、ハードコードされた文字列から `react-router` が提供する `href` ユーティリティ関数 (`href('/tasks/:taskId', { taskId: '123' })` のような形式) を使って生成するように変更しました。
    *   これにより、ルーティングパスの型安全性が向上し、タイポによるバグの削減やリファクタリングの容易化が期待できます。

**影響範囲:**

*   **Tasks機能:**
    *   一覧ページ (`/tasks`): `useSmartNavigation` を使用して現在の表示状態を自動保存。
    *   作成 (`/tasks/create`)、編集 (`/tasks/:task`)、削除 (`/tasks/:task/delete`)、インポート (`/tasks/import`) ページ/モーダル: `useSmartNavigation` を利用して一覧ページへ戻る際のURLを解決。
    *   各コンポーネントでのURL生成に `href` を使用。
*   **Users機能:**
    *   一覧ページ (`/users`): `useSmartNavigation` を使用して現在の表示状態を自動保存。
    *   追加 (`/users/add`)、編集 (`/users/:user/update`)、削除 (`/users/:user/delete`)、招待 (`/users/invite`) モーダル: `useSmartNavigation` を利用して一覧ページへ戻る際のURLを解決。
    *   各コンポーネントでのURL生成に `href` を使用。
*   その他、パンくずリストなど、URLを扱う箇所で `href` ユーティリティを使用。

**期待される効果:**

*   **ユーザー体験の向上:** 一覧ページの状態が保持されるため、よりスムーズな画面遷移が可能になります。
*   **開発効率と保守性の向上:** 型安全なURL生成により、開発時のミスを減らし、コードの信頼性と保守性を高めます。

