### PR TITLE
Bug fix: Pagination resets per_page to default on page change and vice versa 

### DIFF
--- a/app/routes/_authenticated+/tasks+/_index/components/data-table-pagination.tsx
+++ b/app/routes/_authenticated+/tasks+/_index/components/data-table-pagination.tsx
@@ -46,9 +46,13 @@ export function DataTablePagination<TData>({
           <Select
             defaultValue={`${perPage}`}
             onValueChange={(value) => {
+              const newPerPage = Number(value)
+              const newTotalPages = Math.ceil(totalItems / newPerPage)
+
               updatePagination({
-                page: 1,
-                per_page: Number(value),
+                per_page: newPerPage,
+                // Only reset page if current page would be invalid with new per_page
+                ...(page > newTotalPages ? { page: newTotalPages } : {}),
               })
             }}
           >
@@ -73,7 +77,7 @@ export function DataTablePagination<TData>({
             variant="outline"
             className="hidden h-8 w-8 p-0 lg:flex"
             onClick={() => {
-              updatePagination({ page: undefined })
+              updatePagination({ page: 1 })
             }}
             disabled={page === 1}
           >
@@ -85,7 +89,7 @@ export function DataTablePagination<TData>({
             variant="outline"
             className="h-8 w-8 p-0"
             onClick={() => {
-              updatePagination({ page: page === 2 ? undefined : page - 1 })
+              updatePagination({ page: page - 1 })
             }}
             disabled={page === 1}
           >

--- a/app/routes/_authenticated+/tasks+/_index/hooks/use-data-table-state.ts
+++ b/app/routes/_authenticated+/tasks+/_index/hooks/use-data-table-state.ts
@@ -112,13 +112,12 @@ export function useDataTableState() {
         } else {
           prev.set('page', String(newPagination.page))
         }
-        if (
-          newPagination.per_page === Number(PAGINATION_PER_PAGE_DEFAULT) ||
-          newPagination.per_page === undefined
-        ) {
-          prev.delete('per_page')
-        } else {
-          prev.set('per_page', String(newPagination.per_page))
+        if (newPagination.per_page !== undefined) {
+          if (newPagination.per_page === Number(PAGINATION_PER_PAGE_DEFAULT)) {
+            prev.delete('per_page')
+          } else {
+            prev.set('per_page', String(newPagination.per_page))
+          }
         }
         return prev
       },

--- a/app/routes/_authenticated+/tasks+/_index/hooks/use-data-table-state.ts
+++ b/app/routes/_authenticated+/tasks+/_index/hooks/use-data-table-state.ts
@@ -57,12 +57,12 @@ export function useDataTableState() {
               prev.set(key, value)
             }
           }
+          prev.delete('page')
           return prev
         },
         { preventScrollReset: true },
       )
     })
-    updatePagination({ page: undefined })
   }
 
   const updateFilters = (newFilters: Partial<Filters>) => {
@@ -80,11 +80,11 @@ export function useDataTableState() {
             prev.delete(key)
           }
         }
+        prev.delete('page')
         return prev
       },
       { preventScrollReset: true },
     )
-    updatePagination({ page: undefined })
   }
 
   const updateSort = (newSort: Partial<Sort>) => {
@@ -97,21 +97,20 @@ export function useDataTableState() {
           prev.delete('sort_by')
           prev.delete('sort_order')
         }
+        prev.delete('page')
         return prev
       },
       { preventScrollReset: true },
     )
-    updatePagination({ page: undefined })
   }
 
   const updatePagination = (newPagination: Partial<Pagination>) => {
     setSearchParams(
       (prev) => {
-        if (newPagination.page === 1 || newPagination.page === undefined) {
-          prev.delete('page')
-        } else {
+        if (newPagination.page !== undefined) {
           prev.set('page', String(newPagination.page))
         }
+
         if (newPagination.per_page !== undefined) {
           if (newPagination.per_page === Number(PAGINATION_PER_PAGE_DEFAULT)) {
             prev.delete('per_page')


### PR DESCRIPTION
When navigating to the `/tasks` route and using a non-default `per_page` setting, switching pages in the table causes the `per_page` value to reset to its default.

This happens because the pagination function does not pass a `per_page` value in the `newPagination` object when switching pages. As a result, `newPagination.per_page === undefined`, and the existing `per_page` value is removed.

This PR fixes the issue by ensuring that the per_page logic only runs when per_page is explicitly provided in newPagination.

An identical situation happens with the page number, when changing `per_page` on a non default `page`, it resets to default.
This PR fixes this by ensuring that `page` logic only runs when `page` is explicitly provided in newPagination.

Further changes were implemented to make this new logic work with the arrow buttons, sort, filter and search functions.

On the `users` route you'll find a similar issue, described in issue #37 . The implementation here is slightly different, so a decision will need to be made which implementation is preferred before a bug fix is implemented.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pagination controls to prevent unnecessary page resets and ensure accurate page navigation when changing the number of rows per page.
  * Enhanced URL parameter handling for search, filters, sort, and pagination to provide more consistent and predictable behavior during data table updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->