### PR TITLE
refactor: unify pagination patterns between tasks and users routes

### DIFF
--- a/app/routes/_authenticated+/tasks+/_index/hooks/use-data-table-state.ts
+++ b/app/routes/_authenticated+/tasks+/_index/hooks/use-data-table-state.ts
@@ -108,7 +108,11 @@ export function useDataTableState() {
     setSearchParams(
       (prev) => {
         if (newPagination.page !== undefined) {
-          prev.set('page', String(newPagination.page))
+          if (newPagination.page === 1) {
+            prev.delete('page')
+          } else {
+            prev.set('page', String(newPagination.page))
+          }
         }
 
         if (newPagination.per_page !== undefined) {

--- a/app/routes/_authenticated+/users+/_layout/components/data-table-pagination.tsx
+++ b/app/routes/_authenticated+/users+/_layout/components/data-table-pagination.tsx
@@ -13,7 +13,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '~/components/ui/select'
-import { useDataTableState } from '../hooks/use-data-table-state'
+import { useDataTableState, PAGINATION_PER_PAGE_ITEMS } from '../hooks/use-data-table-state'
 
 interface DataTablePaginationProps<TData> {
   table: Table<TData>
@@ -59,8 +59,8 @@ export function DataTablePagination<TData>({
               <SelectValue placeholder={`${pageSize}`} />
             </SelectTrigger>
             <SelectContent side="top">
-              {[10, 20, 30, 40, 50].map((pageSize) => (
-                <SelectItem key={pageSize} value={`${pageSize}`}>
+              {PAGINATION_PER_PAGE_ITEMS.map((pageSize) => (
+                <SelectItem key={pageSize} value={pageSize}>
                   {pageSize}
                 </SelectItem>
               ))}

--- a/app/routes/_authenticated+/users+/_layout/components/data-table-pagination.tsx
+++ b/app/routes/_authenticated+/users+/_layout/components/data-table-pagination.tsx
@@ -13,7 +13,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from '~/components/ui/select'
-import { useDataTableState, PAGINATION_PER_PAGE_ITEMS } from '../hooks/use-data-table-state'
+import {
+  PAGINATION_PER_PAGE_ITEMS,
+  useDataTableState,
+} from '../hooks/use-data-table-state'
 
 interface DataTablePaginationProps<TData> {
   table: Table<TData>

--- a/app/routes/_authenticated+/users+/_layout/hooks/use-data-table-state.ts
+++ b/app/routes/_authenticated+/users+/_layout/hooks/use-data-table-state.ts
@@ -6,6 +6,7 @@ import { useDebounce } from '~/hooks/use-debounce'
 // Constants
 export const PAGINATION_PER_PAGE_DEFAULT = '20'
 export const PAGINATION_PER_PAGE_ITEMS = ['10', '20', '30', '40', '50'] as const
+export type PerPageString = typeof PAGINATION_PER_PAGE_ITEMS[number]
 
 // Define the types for filters and pagination
 export const QuerySchema = z.object({
@@ -42,13 +43,7 @@ export const PaginationSchema = z.object({
   per_page: z.preprocess(
     (val) => (val === null ? undefined : val),
     z
-      .union([
-        z.literal('10'),
-        z.literal('20'),
-        z.literal('30'),
-        z.literal('40'),
-        z.literal('50'),
-      ])
+      .enum(PAGINATION_PER_PAGE_ITEMS)
       .optional()
       .default(PAGINATION_PER_PAGE_DEFAULT)
       .transform(Number),

--- a/app/routes/_authenticated+/users+/_layout/hooks/use-data-table-state.ts
+++ b/app/routes/_authenticated+/users+/_layout/hooks/use-data-table-state.ts
@@ -6,7 +6,7 @@ import { useDebounce } from '~/hooks/use-debounce'
 // Constants
 export const PAGINATION_PER_PAGE_DEFAULT = '20'
 export const PAGINATION_PER_PAGE_ITEMS = ['10', '20', '30', '40', '50'] as const
-export type PerPageString = typeof PAGINATION_PER_PAGE_ITEMS[number]
+export type PerPageString = (typeof PAGINATION_PER_PAGE_ITEMS)[number]
 
 // Define the types for filters and pagination
 export const QuerySchema = z.object({

--- a/app/routes/_authenticated+/users+/_layout/hooks/use-data-table-state.ts
+++ b/app/routes/_authenticated+/users+/_layout/hooks/use-data-table-state.ts
@@ -3,6 +3,10 @@ import { useSearchParams } from 'react-router'
 import { z } from 'zod'
 import { useDebounce } from '~/hooks/use-debounce'
 
+// Constants
+export const PAGINATION_PER_PAGE_DEFAULT = '20'
+export const PAGINATION_PER_PAGE_ITEMS = ['10', '20', '30', '40', '50'] as const
+
 // Define the types for filters and pagination
 export const QuerySchema = z.object({
   username: z.preprocess(
@@ -46,7 +50,7 @@ export const PaginationSchema = z.object({
         z.literal('50'),
       ])
       .optional()
-      .default('20')
+      .default(PAGINATION_PER_PAGE_DEFAULT)
       .transform(Number),
   ),
 })
@@ -157,7 +161,7 @@ export function useDataTableState() {
         }
 
         if (newPagination.per_page !== undefined) {
-          if (newPagination.per_page === 20) {
+          if (newPagination.per_page === Number(PAGINATION_PER_PAGE_DEFAULT)) {
             prev.delete('per_page')
           } else {
             prev.set('per_page', String(newPagination.per_page))


### PR DESCRIPTION
## Summary
This PR unifies the pagination implementation patterns between `/tasks` and `/users` routes while keeping each route's code independent for easy scaffolding.

## Changes
- Add pagination constants (`PAGINATION_PER_PAGE_DEFAULT`, `PAGINATION_PER_PAGE_ITEMS`) to users route
- Align URL parameter handling:
  - `page=1` is omitted from URL (default)
  - Default `per_page` value is omitted from URL
- Consistent import/export patterns for better scaffolding
- Both routes now follow the same pagination behavior pattern

## Benefits
- Each route remains self-contained for easy copy/paste scaffolding
- Consistent behavior across the application
- Clean URLs (no unnecessary default parameters)
- Predictable pagination patterns for developers

## Testing
1. Navigate to both `/tasks` and `/users` routes
2. Verify pagination works identically on both:
   - Default values don't appear in URL
   - Page and per_page changes work correctly
   - No unexpected resets or parameter loss

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved pagination handling so the first page is no longer shown in the URL, making links cleaner.
  * Centralized default page size and available pagination options for consistency across the app.
  * Updated pagination dropdown to use a consistent set of page size options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->