### PR TITLE
feat: add floating bulk action bar to tasks and users tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ dist-ssr
 build/
 .vercel
 references
+.playwright-mcp

--- a/app/routes/_authenticated/tasks/_index/+components/data-table-floating-bar.tsx
+++ b/app/routes/_authenticated/tasks/_index/+components/data-table-floating-bar.tsx
@@ -5,7 +5,7 @@ import {
   IconZoomReset,
 } from '@tabler/icons-react'
 import type { Table } from '@tanstack/react-table'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { href, useFetcher } from 'react-router'
 import { Button } from '~/components/ui/button'
 import {
@@ -44,17 +44,21 @@ export function DataTableFloatingBar({ table }: DataTableFloatingBarProps) {
   const isUpdating = updateFetcher.state !== 'idle'
   const isPending = isDeleting || isUpdating
 
+  const prevDeletingRef = useRef(false)
   useEffect(() => {
-    if (deleteFetcher.data?.done) {
+    if (prevDeletingRef.current && !isDeleting && deleteFetcher.data?.done) {
       table.resetRowSelection()
     }
-  }, [deleteFetcher.data, table])
+    prevDeletingRef.current = isDeleting
+  }, [isDeleting, deleteFetcher.data, table])
 
+  const prevUpdatingRef = useRef(false)
   useEffect(() => {
-    if (updateFetcher.data?.done) {
+    if (prevUpdatingRef.current && !isUpdating && updateFetcher.data?.done) {
       table.resetRowSelection()
     }
-  }, [updateFetcher.data, table])
+    prevUpdatingRef.current = isUpdating
+  }, [isUpdating, updateFetcher.data, table])
 
   if (selectedCount === 0) return null
 

--- a/app/routes/_authenticated/tasks/_index/+components/data-table-floating-bar.tsx
+++ b/app/routes/_authenticated/tasks/_index/+components/data-table-floating-bar.tsx
@@ -1,0 +1,189 @@
+import {
+  IconLoader,
+  IconTag,
+  IconTrash,
+  IconZoomReset,
+} from '@tabler/icons-react'
+import type { Table } from '@tanstack/react-table'
+import { useEffect } from 'react'
+import { href, useFetcher } from 'react-router'
+import { Button } from '~/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from '~/components/ui/dropdown-menu'
+import { Separator } from '~/components/ui/separator'
+import type { action as bulkDeleteAction } from '../../bulk-delete'
+import type { action as bulkUpdateAction } from '../../bulk-update'
+import { labels } from '../../+shared/data/data'
+import { FILTER_FIELD_LABELS } from '../+config'
+import type { Task } from '../../+shared/data/schema'
+
+interface DataTableFloatingBarProps {
+  table: Table<Task>
+}
+
+export function DataTableFloatingBar({ table }: DataTableFloatingBarProps) {
+  const selectedRows = table.getFilteredSelectedRowModel().rows
+  const selectedCount = selectedRows.length
+
+  const deleteFetcher = useFetcher<typeof bulkDeleteAction>({
+    key: 'tasks-bulk-delete',
+  })
+  const updateFetcher = useFetcher<typeof bulkUpdateAction>({
+    key: 'tasks-bulk-update',
+  })
+
+  const isDeleting = deleteFetcher.state !== 'idle'
+  const isUpdating = updateFetcher.state !== 'idle'
+  const isPending = isDeleting || isUpdating
+
+  useEffect(() => {
+    if (deleteFetcher.data?.done) {
+      table.resetRowSelection()
+    }
+  }, [deleteFetcher.data, table])
+
+  useEffect(() => {
+    if (updateFetcher.data?.done) {
+      table.resetRowSelection()
+    }
+  }, [updateFetcher.data, table])
+
+  if (selectedCount === 0) return null
+
+  const selectedIds = selectedRows.map((row) => row.original.id)
+
+  const handleBulkDelete = () => {
+    const formData = new FormData()
+    for (const id of selectedIds) formData.append('ids', id)
+    deleteFetcher.submit(formData, {
+      action: href('/tasks/bulk-delete'),
+      method: 'POST',
+    })
+  }
+
+  const handleBulkUpdate = (field: 'label' | 'status' | 'priority', value: string) => {
+    const formData = new FormData()
+    for (const id of selectedIds) formData.append('ids', id)
+    formData.append('field', field)
+    formData.append('value', value)
+    updateFetcher.submit(formData, {
+      action: href('/tasks/bulk-update'),
+      method: 'POST',
+    })
+  }
+
+  return (
+    <div className="fixed inset-x-0 bottom-6 z-50 mx-4 flex justify-center sm:mx-auto sm:max-w-xl">
+      <div className="bg-background flex w-full items-center gap-1 rounded-lg border px-3 py-2 shadow-lg">
+        <span className="text-muted-foreground min-w-0 flex-1 whitespace-nowrap text-sm font-medium">
+          {selectedCount} selected
+        </span>
+
+        <div className="flex shrink-0 items-center gap-1">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="hidden sm:flex"
+          onClick={() => table.resetRowSelection()}
+          disabled={isPending}
+        >
+          <IconZoomReset size={16} />
+          Deselect
+        </Button>
+
+        <Separator orientation="vertical" className="mx-1 hidden h-5 sm:block" />
+
+        {/* Label */}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="secondary" size="sm" disabled={isPending}>
+              {isUpdating ? (
+                <IconLoader size={16} className="animate-spin" />
+              ) : (
+                <IconTag size={16} />
+              )}
+              Label
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent>
+            {labels.map((label) => (
+              <DropdownMenuItem
+                key={label.value}
+                onSelect={() => handleBulkUpdate('label', label.value)}
+              >
+                {label.label}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        {/* Status & Priority */}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="secondary" size="sm" disabled={isPending}>
+              {isUpdating ? (
+                <IconLoader size={16} className="animate-spin" />
+              ) : null}
+              <span className="hidden sm:inline">Status / </span>Priority
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger>Status</DropdownMenuSubTrigger>
+              <DropdownMenuSubContent>
+                {FILTER_FIELD_LABELS.status.map((s) => (
+                  <DropdownMenuItem
+                    key={s.value}
+                    onSelect={() => handleBulkUpdate('status', s.value)}
+                  >
+                    {s.icon && <s.icon size={14} className="mr-2" />}
+                    {s.label}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+            <DropdownMenuSeparator />
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger>Priority</DropdownMenuSubTrigger>
+              <DropdownMenuSubContent>
+                {FILTER_FIELD_LABELS.priority.map((p) => (
+                  <DropdownMenuItem
+                    key={p.value}
+                    onSelect={() => handleBulkUpdate('priority', p.value)}
+                  >
+                    {p.icon && <p.icon size={14} className="mr-2" />}
+                    {p.label}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        {/* Delete */}
+        <Button
+          variant="destructive"
+          size="sm"
+          onClick={handleBulkDelete}
+          disabled={isPending}
+        >
+          {isDeleting ? (
+            <IconLoader size={16} className="animate-spin" />
+          ) : (
+            <IconTrash size={16} />
+          )}
+          Delete
+        </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/routes/_authenticated/tasks/_index/+components/data-table-floating-bar.tsx
+++ b/app/routes/_authenticated/tasks/_index/+components/data-table-floating-bar.tsx
@@ -5,7 +5,7 @@ import {
   IconZoomReset,
 } from '@tabler/icons-react'
 import type { Table } from '@tanstack/react-table'
-import { useEffect, useRef } from 'react'
+import { useEffect } from 'react'
 import { href, useFetcher } from 'react-router'
 import { Button } from '~/components/ui/button'
 import {
@@ -44,21 +44,17 @@ export function DataTableFloatingBar({ table }: DataTableFloatingBarProps) {
   const isUpdating = updateFetcher.state !== 'idle'
   const isPending = isDeleting || isUpdating
 
-  const prevDeletingRef = useRef(false)
   useEffect(() => {
-    if (prevDeletingRef.current && !isDeleting && deleteFetcher.data?.done) {
+    if (deleteFetcher.data?.done) {
       table.resetRowSelection()
     }
-    prevDeletingRef.current = isDeleting
-  }, [isDeleting, deleteFetcher.data, table])
+  }, [deleteFetcher.data, table])
 
-  const prevUpdatingRef = useRef(false)
   useEffect(() => {
-    if (prevUpdatingRef.current && !isUpdating && updateFetcher.data?.done) {
+    if (updateFetcher.data?.done) {
       table.resetRowSelection()
     }
-    prevUpdatingRef.current = isUpdating
-  }, [isUpdating, updateFetcher.data, table])
+  }, [updateFetcher.data, table])
 
   if (selectedCount === 0) return null
 

--- a/app/routes/_authenticated/tasks/_index/+components/data-table-floating-bar.tsx
+++ b/app/routes/_authenticated/tasks/_index/+components/data-table-floating-bar.tsx
@@ -19,11 +19,11 @@ import {
   DropdownMenuTrigger,
 } from '~/components/ui/dropdown-menu'
 import { Separator } from '~/components/ui/separator'
+import { FILTER_FIELD_LABELS } from '../+config'
+import { labels } from '../../+shared/data/data'
+import type { Task } from '../../+shared/data/schema'
 import type { action as bulkDeleteAction } from '../../bulk-delete'
 import type { action as bulkUpdateAction } from '../../bulk-update'
-import { labels } from '../../+shared/data/data'
-import { FILTER_FIELD_LABELS } from '../+config'
-import type { Task } from '../../+shared/data/schema'
 
 interface DataTableFloatingBarProps {
   table: Table<Task>
@@ -69,7 +69,10 @@ export function DataTableFloatingBar({ table }: DataTableFloatingBarProps) {
     })
   }
 
-  const handleBulkUpdate = (field: 'label' | 'status' | 'priority', value: string) => {
+  const handleBulkUpdate = (
+    field: 'label' | 'status' | 'priority',
+    value: string,
+  ) => {
     const formData = new FormData()
     for (const id of selectedIds) formData.append('ids', id)
     formData.append('field', field)
@@ -83,105 +86,108 @@ export function DataTableFloatingBar({ table }: DataTableFloatingBarProps) {
   return (
     <div className="fixed inset-x-0 bottom-6 z-50 mx-4 flex justify-center sm:mx-auto sm:max-w-xl">
       <div className="bg-background flex w-full items-center gap-1 rounded-lg border px-3 py-2 shadow-lg">
-        <span className="text-muted-foreground min-w-0 flex-1 whitespace-nowrap text-sm font-medium">
+        <span className="text-muted-foreground min-w-0 flex-1 text-sm font-medium whitespace-nowrap">
           {selectedCount} selected
         </span>
 
         <div className="flex shrink-0 items-center gap-1">
-        <Button
-          variant="ghost"
-          size="sm"
-          className="hidden sm:flex"
-          onClick={() => table.resetRowSelection()}
-          disabled={isPending}
-        >
-          <IconZoomReset size={16} />
-          Deselect
-        </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="hidden sm:flex"
+            onClick={() => table.resetRowSelection()}
+            disabled={isPending}
+          >
+            <IconZoomReset size={16} />
+            Deselect
+          </Button>
 
-        <Separator orientation="vertical" className="mx-1 hidden h-5 sm:block" />
+          <Separator
+            orientation="vertical"
+            className="mx-1 hidden h-5 sm:block"
+          />
 
-        {/* Label */}
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="secondary" size="sm" disabled={isPending}>
-              {isUpdating ? (
-                <IconLoader size={16} className="animate-spin" />
-              ) : (
-                <IconTag size={16} />
-              )}
-              Label
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent>
-            {labels.map((label) => (
-              <DropdownMenuItem
-                key={label.value}
-                onSelect={() => handleBulkUpdate('label', label.value)}
-              >
-                {label.label}
-              </DropdownMenuItem>
-            ))}
-          </DropdownMenuContent>
-        </DropdownMenu>
+          {/* Label */}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="secondary" size="sm" disabled={isPending}>
+                {isUpdating ? (
+                  <IconLoader size={16} className="animate-spin" />
+                ) : (
+                  <IconTag size={16} />
+                )}
+                Label
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent>
+              {labels.map((label) => (
+                <DropdownMenuItem
+                  key={label.value}
+                  onSelect={() => handleBulkUpdate('label', label.value)}
+                >
+                  {label.label}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
 
-        {/* Status & Priority */}
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="secondary" size="sm" disabled={isPending}>
-              {isUpdating ? (
-                <IconLoader size={16} className="animate-spin" />
-              ) : null}
-              <span className="hidden sm:inline">Status / </span>Priority
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent>
-            <DropdownMenuSub>
-              <DropdownMenuSubTrigger>Status</DropdownMenuSubTrigger>
-              <DropdownMenuSubContent>
-                {FILTER_FIELD_LABELS.status.map((s) => (
-                  <DropdownMenuItem
-                    key={s.value}
-                    onSelect={() => handleBulkUpdate('status', s.value)}
-                  >
-                    {s.icon && <s.icon size={14} className="mr-2" />}
-                    {s.label}
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuSubContent>
-            </DropdownMenuSub>
-            <DropdownMenuSeparator />
-            <DropdownMenuSub>
-              <DropdownMenuSubTrigger>Priority</DropdownMenuSubTrigger>
-              <DropdownMenuSubContent>
-                {FILTER_FIELD_LABELS.priority.map((p) => (
-                  <DropdownMenuItem
-                    key={p.value}
-                    onSelect={() => handleBulkUpdate('priority', p.value)}
-                  >
-                    {p.icon && <p.icon size={14} className="mr-2" />}
-                    {p.label}
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuSubContent>
-            </DropdownMenuSub>
-          </DropdownMenuContent>
-        </DropdownMenu>
+          {/* Status & Priority */}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="secondary" size="sm" disabled={isPending}>
+                {isUpdating ? (
+                  <IconLoader size={16} className="animate-spin" />
+                ) : null}
+                <span className="hidden sm:inline">Status / </span>Priority
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent>
+              <DropdownMenuSub>
+                <DropdownMenuSubTrigger>Status</DropdownMenuSubTrigger>
+                <DropdownMenuSubContent>
+                  {FILTER_FIELD_LABELS.status.map((s) => (
+                    <DropdownMenuItem
+                      key={s.value}
+                      onSelect={() => handleBulkUpdate('status', s.value)}
+                    >
+                      {s.icon && <s.icon size={14} className="mr-2" />}
+                      {s.label}
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuSubContent>
+              </DropdownMenuSub>
+              <DropdownMenuSeparator />
+              <DropdownMenuSub>
+                <DropdownMenuSubTrigger>Priority</DropdownMenuSubTrigger>
+                <DropdownMenuSubContent>
+                  {FILTER_FIELD_LABELS.priority.map((p) => (
+                    <DropdownMenuItem
+                      key={p.value}
+                      onSelect={() => handleBulkUpdate('priority', p.value)}
+                    >
+                      {p.icon && <p.icon size={14} className="mr-2" />}
+                      {p.label}
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuSubContent>
+              </DropdownMenuSub>
+            </DropdownMenuContent>
+          </DropdownMenu>
 
-        {/* Delete */}
-        <Button
-          variant="destructive"
-          size="sm"
-          onClick={handleBulkDelete}
-          disabled={isPending}
-        >
-          {isDeleting ? (
-            <IconLoader size={16} className="animate-spin" />
-          ) : (
-            <IconTrash size={16} />
-          )}
-          Delete
-        </Button>
+          {/* Delete */}
+          <Button
+            variant="destructive"
+            size="sm"
+            onClick={handleBulkDelete}
+            disabled={isPending}
+          >
+            {isDeleting ? (
+              <IconLoader size={16} className="animate-spin" />
+            ) : (
+              <IconTrash size={16} />
+            )}
+            Delete
+          </Button>
         </div>
       </div>
     </div>

--- a/app/routes/_authenticated/tasks/_index/+components/data-table.tsx
+++ b/app/routes/_authenticated/tasks/_index/+components/data-table.tsx
@@ -15,25 +15,27 @@ import {
   TableHeader,
   TableRow,
 } from '~/components/ui/table'
+import type { Task } from '../../+shared/data/schema'
+import { DataTableFloatingBar } from './data-table-floating-bar'
 import {
   DataTablePagination,
   type PaginationProps,
 } from './data-table-pagination'
 import { DataTableToolbar, type FacetedCountProps } from './data-table-toolbar'
 
-interface DataTableProps<TData, TValue> {
-  columns: ColumnDef<TData, TValue>[]
-  data: TData[]
+interface DataTableProps {
+  columns: ColumnDef<Task>[]
+  data: Task[]
   pagination: PaginationProps
   facetedCounts?: FacetedCountProps
 }
 
-export function DataTable<TData, TValue>({
+export function DataTable({
   columns,
   data,
   pagination,
   facetedCounts,
-}: DataTableProps<TData, TValue>) {
+}: DataTableProps) {
   const [rowSelection, setRowSelection] = React.useState({})
   const [columnVisibility, setColumnVisibility] =
     React.useState<VisibilityState>({})
@@ -106,6 +108,7 @@ export function DataTable<TData, TValue>({
         </Table>
       </div>
       <DataTablePagination table={table} pagination={pagination} />
+      <DataTableFloatingBar table={table} />
     </div>
   )
 }

--- a/app/routes/_authenticated/tasks/bulk-delete.ts
+++ b/app/routes/_authenticated/tasks/bulk-delete.ts
@@ -1,0 +1,27 @@
+import { setTimeout as sleep } from 'node:timers/promises'
+import { dataWithSuccess } from 'remix-toast'
+import { z } from 'zod'
+import { tasks } from './+shared/data/tasks'
+import type { Route } from './+types/bulk-delete'
+
+const schema = z.object({
+  ids: z.array(z.string()).min(1),
+})
+
+export const action = async ({ request }: Route.ActionArgs) => {
+  const formData = await request.formData()
+  const { ids } = schema.parse({ ids: formData.getAll('ids') })
+
+  await sleep(500)
+  for (const id of ids) {
+    const index = tasks.findIndex((t) => t.id === id)
+    if (index !== -1) tasks.splice(index, 1)
+  }
+
+  return dataWithSuccess(
+    { done: true },
+    {
+      message: `${ids.length} task${ids.length > 1 ? 's' : ''} deleted`,
+    },
+  )
+}

--- a/app/routes/_authenticated/tasks/bulk-update.ts
+++ b/app/routes/_authenticated/tasks/bulk-update.ts
@@ -4,24 +4,22 @@ import { z } from 'zod'
 import { tasks } from './+shared/data/tasks'
 import type { Route } from './+types/bulk-update'
 
-const schema = z
-  .object({ ids: z.array(z.string()).min(1) })
-  .and(
-    z.discriminatedUnion('field', [
-      z.object({
-        field: z.literal('label'),
-        value: z.enum(['bug', 'feature', 'documentation']),
-      }),
-      z.object({
-        field: z.literal('status'),
-        value: z.enum(['backlog', 'todo', 'in progress', 'done', 'canceled']),
-      }),
-      z.object({
-        field: z.literal('priority'),
-        value: z.enum(['high', 'medium', 'low']),
-      }),
-    ]),
-  )
+const schema = z.object({ ids: z.array(z.string()).min(1) }).and(
+  z.discriminatedUnion('field', [
+    z.object({
+      field: z.literal('label'),
+      value: z.enum(['bug', 'feature', 'documentation']),
+    }),
+    z.object({
+      field: z.literal('status'),
+      value: z.enum(['backlog', 'todo', 'in progress', 'done', 'canceled']),
+    }),
+    z.object({
+      field: z.literal('priority'),
+      value: z.enum(['high', 'medium', 'low']),
+    }),
+  ]),
+)
 
 export const action = async ({ request }: Route.ActionArgs) => {
   const formData = await request.formData()

--- a/app/routes/_authenticated/tasks/bulk-update.ts
+++ b/app/routes/_authenticated/tasks/bulk-update.ts
@@ -4,11 +4,24 @@ import { z } from 'zod'
 import { tasks } from './+shared/data/tasks'
 import type { Route } from './+types/bulk-update'
 
-const schema = z.object({
-  ids: z.array(z.string()).min(1),
-  field: z.enum(['label', 'status', 'priority']),
-  value: z.string(),
-})
+const schema = z
+  .object({ ids: z.array(z.string()).min(1) })
+  .and(
+    z.discriminatedUnion('field', [
+      z.object({
+        field: z.literal('label'),
+        value: z.enum(['bug', 'feature', 'documentation']),
+      }),
+      z.object({
+        field: z.literal('status'),
+        value: z.enum(['backlog', 'todo', 'in progress', 'done', 'canceled']),
+      }),
+      z.object({
+        field: z.literal('priority'),
+        value: z.enum(['high', 'medium', 'low']),
+      }),
+    ]),
+  )
 
 export const action = async ({ request }: Route.ActionArgs) => {
   const formData = await request.formData()

--- a/app/routes/_authenticated/tasks/bulk-update.ts
+++ b/app/routes/_authenticated/tasks/bulk-update.ts
@@ -1,0 +1,34 @@
+import { setTimeout as sleep } from 'node:timers/promises'
+import { dataWithSuccess } from 'remix-toast'
+import { z } from 'zod'
+import { tasks } from './+shared/data/tasks'
+import type { Route } from './+types/bulk-update'
+
+const schema = z.object({
+  ids: z.array(z.string()).min(1),
+  field: z.enum(['label', 'status', 'priority']),
+  value: z.string(),
+})
+
+export const action = async ({ request }: Route.ActionArgs) => {
+  const formData = await request.formData()
+  const { ids, field, value } = schema.parse({
+    ids: formData.getAll('ids'),
+    field: formData.get('field'),
+    value: formData.get('value'),
+  })
+
+  await sleep(500)
+  for (const id of ids) {
+    const task = tasks.find((t) => t.id === id)
+    if (task) task[field] = value
+  }
+
+  return dataWithSuccess(
+    { done: true },
+    {
+      message: `${ids.length} task${ids.length > 1 ? 's' : ''} updated`,
+      description: `${field} set to "${value}"`,
+    },
+  )
+}

--- a/app/routes/_authenticated/users/_index/+components/data-table-floating-bar.tsx
+++ b/app/routes/_authenticated/users/_index/+components/data-table-floating-bar.tsx
@@ -1,6 +1,6 @@
 import { IconLoader, IconTrash, IconZoomReset } from '@tabler/icons-react'
 import type { Table } from '@tanstack/react-table'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { href, useFetcher } from 'react-router'
 import { Button } from '~/components/ui/button'
 import { Separator } from '~/components/ui/separator'
@@ -21,11 +21,13 @@ export function DataTableFloatingBar({ table }: DataTableFloatingBarProps) {
 
   const isDeleting = deleteFetcher.state !== 'idle'
 
+  const prevDeletingRef = useRef(false)
   useEffect(() => {
-    if (deleteFetcher.data?.done) {
+    if (prevDeletingRef.current && !isDeleting && deleteFetcher.data?.done) {
       table.resetRowSelection()
     }
-  }, [deleteFetcher.data, table])
+    prevDeletingRef.current = isDeleting
+  }, [isDeleting, deleteFetcher.data, table])
 
   if (selectedCount === 0) return null
 

--- a/app/routes/_authenticated/users/_index/+components/data-table-floating-bar.tsx
+++ b/app/routes/_authenticated/users/_index/+components/data-table-floating-bar.tsx
@@ -1,6 +1,6 @@
 import { IconLoader, IconTrash, IconZoomReset } from '@tabler/icons-react'
 import type { Table } from '@tanstack/react-table'
-import { useEffect, useRef } from 'react'
+import { useEffect } from 'react'
 import { href, useFetcher } from 'react-router'
 import { Button } from '~/components/ui/button'
 import { Separator } from '~/components/ui/separator'
@@ -21,13 +21,11 @@ export function DataTableFloatingBar({ table }: DataTableFloatingBarProps) {
 
   const isDeleting = deleteFetcher.state !== 'idle'
 
-  const prevDeletingRef = useRef(false)
   useEffect(() => {
-    if (prevDeletingRef.current && !isDeleting && deleteFetcher.data?.done) {
+    if (deleteFetcher.data?.done) {
       table.resetRowSelection()
     }
-    prevDeletingRef.current = isDeleting
-  }, [isDeleting, deleteFetcher.data, table])
+  }, [deleteFetcher.data, table])
 
   if (selectedCount === 0) return null
 

--- a/app/routes/_authenticated/users/_index/+components/data-table-floating-bar.tsx
+++ b/app/routes/_authenticated/users/_index/+components/data-table-floating-bar.tsx
@@ -1,0 +1,81 @@
+import { IconLoader, IconTrash, IconZoomReset } from '@tabler/icons-react'
+import type { Table } from '@tanstack/react-table'
+import { useEffect } from 'react'
+import { href, useFetcher } from 'react-router'
+import { Button } from '~/components/ui/button'
+import { Separator } from '~/components/ui/separator'
+import type { action as bulkDeleteAction } from '../../bulk-delete'
+import type { User } from '../../+data/schema'
+
+interface DataTableFloatingBarProps {
+  table: Table<User>
+}
+
+export function DataTableFloatingBar({ table }: DataTableFloatingBarProps) {
+  const selectedRows = table.getFilteredSelectedRowModel().rows
+  const selectedCount = selectedRows.length
+
+  const deleteFetcher = useFetcher<typeof bulkDeleteAction>({
+    key: 'users-bulk-delete',
+  })
+
+  const isDeleting = deleteFetcher.state !== 'idle'
+
+  useEffect(() => {
+    if (deleteFetcher.data?.done) {
+      table.resetRowSelection()
+    }
+  }, [deleteFetcher.data, table])
+
+  if (selectedCount === 0) return null
+
+  const selectedIds = selectedRows.map((row) => row.original.id)
+
+  const handleBulkDelete = () => {
+    const formData = new FormData()
+    for (const id of selectedIds) formData.append('ids', id)
+    deleteFetcher.submit(formData, {
+      action: href('/users/bulk-delete'),
+      method: 'POST',
+    })
+  }
+
+  return (
+    <div className="fixed inset-x-0 bottom-6 z-50 mx-4 flex justify-center sm:mx-auto sm:max-w-sm">
+      <div className="bg-background flex w-full items-center gap-1 rounded-lg border px-3 py-2 shadow-lg">
+        <span className="text-muted-foreground min-w-0 flex-1 whitespace-nowrap text-sm font-medium">
+          {selectedCount} selected
+        </span>
+
+        <div className="flex shrink-0 items-center gap-1">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="hidden sm:flex"
+            onClick={() => table.resetRowSelection()}
+            disabled={isDeleting}
+          >
+            <IconZoomReset size={16} />
+            Deselect
+          </Button>
+
+          <Separator orientation="vertical" className="mx-1 hidden h-5 sm:block" />
+
+          <Button
+            variant="destructive"
+            size="sm"
+            onClick={handleBulkDelete}
+            disabled={isDeleting}
+          >
+            {isDeleting ? (
+              <IconLoader size={16} className="animate-spin" />
+            ) : (
+              <IconTrash size={16} />
+            )}
+            Delete
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/routes/_authenticated/users/_index/+components/data-table-floating-bar.tsx
+++ b/app/routes/_authenticated/users/_index/+components/data-table-floating-bar.tsx
@@ -4,8 +4,8 @@ import { useEffect } from 'react'
 import { href, useFetcher } from 'react-router'
 import { Button } from '~/components/ui/button'
 import { Separator } from '~/components/ui/separator'
-import type { action as bulkDeleteAction } from '../../bulk-delete'
 import type { User } from '../../+data/schema'
+import type { action as bulkDeleteAction } from '../../bulk-delete'
 
 interface DataTableFloatingBarProps {
   table: Table<User>
@@ -43,7 +43,7 @@ export function DataTableFloatingBar({ table }: DataTableFloatingBarProps) {
   return (
     <div className="fixed inset-x-0 bottom-6 z-50 mx-4 flex justify-center sm:mx-auto sm:max-w-sm">
       <div className="bg-background flex w-full items-center gap-1 rounded-lg border px-3 py-2 shadow-lg">
-        <span className="text-muted-foreground min-w-0 flex-1 whitespace-nowrap text-sm font-medium">
+        <span className="text-muted-foreground min-w-0 flex-1 text-sm font-medium whitespace-nowrap">
           {selectedCount} selected
         </span>
 
@@ -59,7 +59,10 @@ export function DataTableFloatingBar({ table }: DataTableFloatingBarProps) {
             Deselect
           </Button>
 
-          <Separator orientation="vertical" className="mx-1 hidden h-5 sm:block" />
+          <Separator
+            orientation="vertical"
+            className="mx-1 hidden h-5 sm:block"
+          />
 
           <Button
             variant="destructive"

--- a/app/routes/_authenticated/users/_index/+components/users-table.tsx
+++ b/app/routes/_authenticated/users/_index/+components/users-table.tsx
@@ -21,6 +21,7 @@ import {
   DataTablePagination,
   type PaginationProps,
 } from './data-table-pagination'
+import { DataTableFloatingBar } from './data-table-floating-bar'
 import { DataTableToolbar, type FacetedCountProps } from './data-table-toolbar'
 
 declare module '@tanstack/react-table' {
@@ -121,6 +122,7 @@ export function UsersTable({
         </Table>
       </div>
       <DataTablePagination table={table} pagination={pagination} />
+      <DataTableFloatingBar table={table} />
     </div>
   )
 }

--- a/app/routes/_authenticated/users/_index/+components/users-table.tsx
+++ b/app/routes/_authenticated/users/_index/+components/users-table.tsx
@@ -17,11 +17,11 @@ import {
   TableRow,
 } from '~/components/ui/table'
 import type { User } from '../../+data/schema'
+import { DataTableFloatingBar } from './data-table-floating-bar'
 import {
   DataTablePagination,
   type PaginationProps,
 } from './data-table-pagination'
-import { DataTableFloatingBar } from './data-table-floating-bar'
 import { DataTableToolbar, type FacetedCountProps } from './data-table-toolbar'
 
 declare module '@tanstack/react-table' {

--- a/app/routes/_authenticated/users/bulk-delete.ts
+++ b/app/routes/_authenticated/users/bulk-delete.ts
@@ -1,0 +1,27 @@
+import { setTimeout as sleep } from 'node:timers/promises'
+import { dataWithSuccess } from 'remix-toast'
+import { z } from 'zod'
+import { users } from './+data/users'
+import type { Route } from './+types/bulk-delete'
+
+const schema = z.object({
+  ids: z.array(z.string()).min(1),
+})
+
+export const action = async ({ request }: Route.ActionArgs) => {
+  const formData = await request.formData()
+  const { ids } = schema.parse({ ids: formData.getAll('ids') })
+
+  await sleep(500)
+  for (const id of ids) {
+    const index = users.findIndex((u) => u.id === id)
+    if (index !== -1) users.splice(index, 1)
+  }
+
+  return dataWithSuccess(
+    { done: true },
+    {
+      message: `${ids.length} user${ids.length > 1 ? 's' : ''} deleted`,
+    },
+  )
+}


### PR DESCRIPTION
## Summary

- Tasks page: show floating action bar on row selection for bulk delete, label update, and status/priority update
- Users page: show floating action bar on row selection for bulk delete
- Uses `useFetcher` to submit bulk operations without navigation
- Responsive layout: Deselect button hidden on mobile, count text won't get squeezed by buttons

## Test plan

- [ ] Select multiple rows on the Tasks page and verify the floating bar appears
- [ ] Verify bulk delete works and row selection is cleared on completion
- [ ] Verify bulk Label / Status / Priority update works
- [ ] Select multiple rows on the Users page and verify bulk delete works
- [ ] Verify layout is not broken at mobile width (390px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added bulk action capabilities for tasks: delete and update labels, status, or priority for multiple tasks at once.
  * Added bulk delete action for users.
  * Floating action bar appears when rows are selected, displaying selected count and available bulk actions with loading indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->